### PR TITLE
Add command line interface

### DIFF
--- a/awattar/__init__.py
+++ b/awattar/__init__.py
@@ -3,6 +3,7 @@
 
 from .client import AwattarClient
 from .marketitem import MarketItem
+from .cli import cli as _cli    # for CLI entry only
 
 __all__ = [
     'AwattarClient'

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -83,10 +83,6 @@ def fetch_prices(
         date = datetime.datetime.combine(date, datetime.time.min, tz.tzlocal())
         items = _get_for_day(date)
     else:
-        if not start:
-            start = datetime.datetime.combine(datetime.date.today(), datetime.time.min, tz.tzlocal())
-        if not end:
-            end = start + datetime.timedelta(1)
         items = _get_for_period(start, end)
     out_items = [item.to_json_dict() for item in items]
     if format == "json":

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -49,7 +49,11 @@ def cli(ctx, country):
     default=None,
     help="the year, month, and day for which to fetch the data",
 )
-@click.option("--format", type=click.Choice(["json", "csv"]), default="json")
+@click.option(
+    "--format",
+    type=click.Choice(["json", "json-pretty", "csv", "csv-pretty"]),
+    default="json-pretty",
+)
 @click.argument("FILE", type=click.File(mode="w"), default="-")
 def fetch(
     start: Optional[datetime.datetime],
@@ -76,11 +80,14 @@ def fetch(
         items = _get_for_period(start, end)
     out_items = [item.to_json_dict() for item in items]
     if format == "json":
+        file.write(json.dumps(out_items))
+    elif format == "json-pretty":
         file.write(json.dumps(out_items, indent=4))
     else:
+        dialect = "excel-tab" if "pretty" in format else "excel"
         # default lineterminator led to duplicate newlines in file when running from git bash on Windows
         writer = csv.DictWriter(
-            file, out_items[0].keys(), lineterminator="\n", dialect="excel-tab"
+            file, out_items[0].keys(), lineterminator="\n", dialect=dialect
         )
         writer.writeheader()
         writer.writerows(out_items)

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -55,7 +55,7 @@ def cli(ctx, country):
     default="json-pretty",
 )
 @click.argument("FILE", type=click.File(mode="w"), default="-")
-def fetch(
+def fetch_prices(
     start: Optional[datetime.datetime],
     end: Optional[datetime.datetime],
     year: Optional[datetime.datetime],

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -1,0 +1,29 @@
+import datetime
+import json
+
+import click
+from dateutil import tz
+
+from awattar.client import AwattarClient
+
+
+@click.group
+def cli():
+    pass
+
+
+@cli.command
+def fetch():
+    """Fetch hourly energy prices for Germany provided via aWATTar's API."""
+    today = datetime.date.today()
+    start: datetime.datetime = datetime.datetime.combine(
+        today, datetime.time.min, tz.tzlocal()
+    )
+    end: datetime.datetime = datetime.timedelta(1) + start
+    print(start)
+    print(end)
+    client = AwattarClient("DE")
+    items = client.request(start, end)
+    item = items[0]
+    print(item)
+    print(json.dumps([item.to_json_dict() for item in items], indent=4))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -98,6 +98,8 @@ def fetch_prices(
         items = _get_for_day(date)
     else:
         items = _get_for_period(start, end)
+
+    # write data to the provided file (or print to stdout)
     out_items = [item.to_json_dict() for item in items]
     if format == "json":
         file.write(json.dumps(out_items))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -35,9 +35,5 @@ def fetch(obj: CliContext):
         today, datetime.time.min, tz.tzlocal()
     )
     end: datetime.datetime = datetime.timedelta(1) + start
-    print(start)
-    print(end)
     items = obj.client.request(start, end)
-    item = items[0]
-    print(item)
     print(json.dumps([item.to_json_dict() for item in items], indent=4))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -2,6 +2,7 @@ import csv
 import dataclasses
 import datetime
 import json
+import sys
 from typing import Optional
 
 import click
@@ -107,6 +108,11 @@ def fetch_prices(
         items = _get_for_day(date)
     else:
         items = _get_for_period(start, end)
+
+    # make sure we got some data from the API
+    if not items:
+        click.echo("Error when fetching data: no data received", sys.stderr)
+        raise click.Abort()
 
     # write data to the provided file (or print to stdout)
     out_items = [item.to_json_dict() for item in items]

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -54,6 +54,8 @@ def cli(ctx, country):
     type=click.Choice(["json", "json-pretty", "csv", "csv-pretty"]),
     default="json-pretty",
 )
+@click.option("--today", is_flag=True, default=False)
+@click.option("--tomorrow", is_flag=True, default=False)
 @click.argument("FILE", type=click.File(mode="w"), default="-")
 def fetch_prices(
     start: Optional[datetime.datetime],
@@ -61,6 +63,8 @@ def fetch_prices(
     year: Optional[datetime.datetime],
     month: Optional[datetime.datetime],
     day: Optional[datetime.datetime],
+    today: bool,
+    tomorrow: bool,
     format: str,
     file: click.File,
 ):
@@ -71,10 +75,16 @@ def fetch_prices(
         items = _get_for_month(month.astimezone(tz.tzlocal()))
     elif year:
         items = _get_for_year(year.astimezone(tz.tzlocal()))
+    elif today:
+        date = datetime.datetime.combine(datetime.date.today(), datetime.time.min, tz.tzlocal())
+        items = _get_for_day(date)
+    elif tomorrow:
+        date = datetime.date.today() + datetime.timedelta(1)
+        date = datetime.datetime.combine(date, datetime.time.min, tz.tzlocal())
+        items = _get_for_day(date)
     else:
-        today = datetime.date.today()
         if not start:
-            start = datetime.datetime.combine(today, datetime.time.min, tz.tzlocal())
+            start = datetime.datetime.combine(datetime.date.today(), datetime.time.min, tz.tzlocal())
         if not end:
             end = start + datetime.timedelta(1)
         items = _get_for_period(start, end)

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -49,7 +49,7 @@ def cli(ctx, country):
     default=None,
     help="the year, month, and day for which to fetch the data",
 )
-@click.option("--format",type=click.Choice(["json", "csv"]), default="json")
+@click.option("--format", type=click.Choice(["json", "csv"]), default="json")
 @click.argument("FILE", type=click.File(mode="w"), default="-")
 def fetch(
     start: Optional[datetime.datetime],
@@ -79,7 +79,9 @@ def fetch(
         file.write(json.dumps(out_items, indent=4))
     else:
         # default lineterminator led to duplicate newlines in file when running from git bash on Windows
-        writer = csv.DictWriter(file, out_items[0].keys(), lineterminator="\n", dialect="excel-tab")
+        writer = csv.DictWriter(
+            file, out_items[0].keys(), lineterminator="\n", dialect="excel-tab"
+        )
         writer.writeheader()
         writer.writerows(out_items)
 

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -76,7 +76,9 @@ def fetch_prices(
     elif year:
         items = _get_for_year(year.astimezone(tz.tzlocal()))
     elif today:
-        date = datetime.datetime.combine(datetime.date.today(), datetime.time.min, tz.tzlocal())
+        date = datetime.datetime.combine(
+            datetime.date.today(), datetime.time.min, tz.tzlocal()
+        )
         items = _get_for_day(date)
     elif tomorrow:
         date = datetime.date.today() + datetime.timedelta(1)

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -93,7 +93,10 @@ def fetch_prices(
         dialect = "excel-tab" if "pretty" in format else "excel"
         # default lineterminator led to duplicate newlines in file when running from git bash on Windows
         writer = csv.DictWriter(
-            file, out_items[0].keys(), lineterminator="\n", dialect=dialect
+            file,
+            out_items[0].keys() if out_items else [],
+            lineterminator="\n",
+            dialect=dialect,
         )
         writer.writeheader()
         writer.writerows(out_items)

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -79,7 +79,16 @@ def fetch_prices(
         raise click.UsageError(
             "--start and --end parameters are mutually exclusiv with any of --day, --month, --year, --today, and --tomorrow."
         )
-
+    # The API allows supplying a value for end without one for start as well as
+    # an end date earlier than start date, and returns default data (current
+    # day UTC) in these cases. However, this is not really intuitive and should
+    # probably better be prevented in the first place.
+    if not start and end:
+        raise click.BadOptionUsage("--end", "--end cannot be supplied without --start")
+    if start and end and not (start < end):
+        raise click.BadParameter(
+            "--start not earlier than --end", param_hint=["--start", "--end"]
+        )
     # fetch data
     if day:
         items = _get_for_day(day.astimezone(tz.tzlocal()))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -31,14 +31,18 @@ def cli(ctx, country):
 @click.pass_obj
 @click.option("--start", type=click.DateTime(), default=None)
 @click.option("--end", type=click.DateTime(), default=None)
-def fetch(obj: CliContext, start: Optional[datetime.datetime], end: Optional[datetime.datetime]):
+@click.option("--year", type=click.DateTime(["%Y"]), default=None, help="the year for which to fetch the data")
+def fetch(obj: CliContext, start: Optional[datetime.datetime], end: Optional[datetime.datetime], year: Optional[datetime.datetime]):
     """Fetch hourly energy prices"""
     today = datetime.date.today()
     if not start:
         start = datetime.datetime.combine(
-            today, datetime.time.min, tz.tzlocal()
+            today if not year else year, datetime.time.min, tz.tzlocal()
         )
     if not end:
-        end = datetime.timedelta(1) + start
+        if not year :
+            end = start + datetime.timedelta(1)
+        else:
+            end = start.replace(year=start.year + 1)
     items = obj.client.request(start, end)
     print(json.dumps([item.to_json_dict() for item in items], indent=4))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -69,6 +69,18 @@ def fetch_prices(
     file: click.File,
 ):
     """Fetch hourly energy prices"""
+    # validate parameter combination
+    single = list(map(bool, [day, month, year, today, tomorrow]))
+    if sum(single) > 1:
+        raise click.UsageError(
+            "--day, --month, --year, --today, and --tomorrow are mutually exclusive parameters. Please specify at most one of them."
+        )
+    if any(single) and (start or end):
+        raise click.UsageError(
+            "--start and --end parameters are mutually exclusiv with any of --day, --month, --year, --today, and --tomorrow."
+        )
+
+    # fetch data
     if day:
         items = _get_for_day(day.astimezone(tz.tzlocal()))
     elif month:

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -42,19 +42,28 @@ def cli(ctx, country):
     default=None,
     help="the year and month for which to fetch the data",
 )
+@click.option(
+    "--day",
+    type=click.DateTime(["%Y-%m-%d"]),
+    default=None,
+    help="the year, month, and day for which to fetch the data",
+)
 def fetch(
     start: Optional[datetime.datetime],
     end: Optional[datetime.datetime],
     year: Optional[datetime.datetime],
     month: Optional[datetime.datetime],
+    day: Optional[datetime.datetime],
 ):
     """Fetch hourly energy prices"""
-    today = datetime.date.today()
-    if month:
+    if day:
+        items = _get_for_day(day.astimezone(tz.tzlocal()))
+    elif month:
         items = _get_for_month(month.astimezone(tz.tzlocal()))
     elif year:
         items = _get_for_year(year.astimezone(tz.tzlocal()))
     else:
+        today = datetime.date.today()
         if not start:
             start = datetime.datetime.combine(today, datetime.time.min, tz.tzlocal())
         if not end:
@@ -78,3 +87,7 @@ def _get_for_month(month: datetime.datetime):
         return _get_for_period(month, month.replace(month=month.month + 1))
     except ValueError:
         return _get_for_period(month, month.replace(year=month.year + 1, month=1))
+
+
+def _get_for_day(day: datetime.datetime):
+    return _get_for_period(day, day + datetime.timedelta(1))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import dataclasses
+from typing import Optional
 
 import click
 from dateutil import tz
@@ -28,12 +29,16 @@ def cli(ctx, country):
 
 @cli.command
 @click.pass_obj
-def fetch(obj: CliContext):
+@click.option("--start", type=click.DateTime(), default=None)
+@click.option("--end", type=click.DateTime(), default=None)
+def fetch(obj: CliContext, start: Optional[datetime.datetime], end: Optional[datetime.datetime]):
     """Fetch hourly energy prices"""
     today = datetime.date.today()
-    start: datetime.datetime = datetime.datetime.combine(
-        today, datetime.time.min, tz.tzlocal()
-    )
-    end: datetime.datetime = datetime.timedelta(1) + start
+    if not start:
+        start = datetime.datetime.combine(
+            today, datetime.time.min, tz.tzlocal()
+        )
+    if not end:
+        end = datetime.timedelta(1) + start
     items = obj.client.request(start, end)
     print(json.dumps([item.to_json_dict() for item in items], indent=4))

--- a/awattar/cli.py
+++ b/awattar/cli.py
@@ -13,6 +13,8 @@ from awattar.client import AwattarClient
 
 @dataclasses.dataclass
 class CliContext:
+    """Used as click's context object"""
+
     client: AwattarClient
 
 
@@ -30,33 +32,33 @@ def cli(ctx, country):
 
 
 @cli.command
-@click.option("--start", type=click.DateTime(), default=None)
-@click.option("--end", type=click.DateTime(), default=None)
+@click.option("--start", type=click.DateTime(), default=None, help="the start date in local time of the interval for which to fetch the prices")
+@click.option("--end", type=click.DateTime(), default=None, help="the end date in local time of the interval for which to fetch the prices")
 @click.option(
     "--year",
     type=click.DateTime(["%Y"]),
     default=None,
-    help="the year for which to fetch the data",
+    help="year in local time for which to fetch the prices",
 )
 @click.option(
     "--month",
     type=click.DateTime(["%Y-%m"]),
     default=None,
-    help="the year and month for which to fetch the data",
+    help="year and month in local time for which to fetch the prices",
 )
 @click.option(
     "--day",
     type=click.DateTime(["%Y-%m-%d"]),
     default=None,
-    help="the year, month, and day for which to fetch the data",
+    help="year, month, and day in local time for which to fetch the prices",
 )
 @click.option(
     "--format",
     type=click.Choice(["json", "json-pretty", "csv", "csv-pretty"]),
     default="json-pretty",
 )
-@click.option("--today", is_flag=True, default=False)
-@click.option("--tomorrow", is_flag=True, default=False)
+@click.option("--today", is_flag=True, default=False, help="fetch today's (local time) prices")
+@click.option("--tomorrow", is_flag=True, default=False, help="fetch tomorrow's (local time) prices (will only work after they've been published at 12:55 GMT")
 @click.argument("FILE", type=click.File(mode="w"), default="-")
 def fetch_prices(
     start: Optional[datetime.datetime],
@@ -90,6 +92,7 @@ def fetch_prices(
         raise click.BadParameter(
             "--start not earlier than --end", param_hint=["--start", "--end"]
         )
+
     # fetch data
     if day:
         items = _get_for_day(day.astimezone(tz.tzlocal()))

--- a/awattar/marketitem.py
+++ b/awattar/marketitem.py
@@ -18,6 +18,17 @@ class MarketItem(object):
         self._marketprice = float(marketprice)
         self._unit = unit
 
+    def to_json_dict(self):
+        return {
+                "start": self.start_datetime.isoformat(),
+                "end": self.end_datetime.isoformat(),
+                "price": self.marketprice,
+                "unit": self.unit,
+                "currency": self.currency,
+                "energy_unit": self.energy_unit,
+                "price_per_kWh": self.price_per_kWh
+            }
+
     @classmethod
     def by_timestamp(cls,
                  start_timestamp : datetime,
@@ -66,4 +77,4 @@ class MarketItem(object):
 
     @property
     def unit(self):
-        return self._unit;        
+        return self._unit;

--- a/awattar/marketitem.py
+++ b/awattar/marketitem.py
@@ -78,3 +78,28 @@ class MarketItem(object):
     @property
     def unit(self):
         return self._unit;
+
+    @property
+    def price_per_kWh(self):
+        try:
+            return self._price_per_kWh
+        except AttributeError:
+            assert self.energy_unit.startswith("M")
+            self._price_per_kWh = self.marketprice / 1000
+        return self._price_per_kWh
+
+    @property
+    def currency(self):
+        try:
+            return self._currency
+        except AttributeError:
+            self._currency = self.unit.split("/")[0]
+        return self._currency
+
+    @property
+    def energy_unit(self):
+        try:
+            return self._energy_unit
+        except AttributeError:
+            self._energy_unit = self.unit.split("/")[1]
+        return self._energy_unit

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,11 @@ setuptools.setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',        
     ],
-    install_requires=['requests', 'datetime', 'python-dateutil'],
-    python_requires='>=3.6'
-)
+    install_requires=['requests', 'datetime', 'python-dateutil', 'click'],
+    python_requires='>=3.6',
+    entry_points={
+            'console_scripts': [
+                'awattar = awattar:_cli',
+            ]
+    },
+    )


### PR DESCRIPTION
This pull request adds a CLI based on `click`, which makes accessing the API from a terminal quite convenient by allowing users to specify dates in human readable format instead of Unix timestamps and providing shortcuts for getting the prices for certain intervals like one year, month, or day (including today and tomorrow).
The price data can either be printed to `stdout` or  written to disk in JSON or CSV formats.

I also added a few more properties to `MarketItem` unpacking the `unit` field into `currency` and `energy_unit` as well as providing a kWh based price which at least in Germany is the regular unit for electrical energy at household level.

Let me know what you think about these additions, and if you want me to change anything (e.g. split the additional properties into a separate pull request).